### PR TITLE
Sort notebook violations by cell order, not cell ID

### DIFF
--- a/chkstyle/core.py
+++ b/chkstyle/core.py
@@ -320,14 +320,14 @@ def check_notebook(path: str) -> list[tuple]:
     "Check Jupyter notebook for style violations."
     with open(path, encoding="utf-8") as f: nb = json.load(f)
     violations = []
-    for cell in nb.get("cells", []):
+    for idx, cell in enumerate(nb.get("cells", [])):
         if cell.get("cell_type") != "code": continue
         cell_id = cell.get("id", "unknown")
         source_lines = cell.get("source", [])
         if isinstance(source_lines, str): source = source_lines
         else: source = "".join(source_lines)
         if not source.strip(): continue
-        cell_path = f"{path}:cell[{cell_id}]"
+        cell_path = f"{path}:cell[{idx:03d}#{cell_id}]"
         cell_violations = check_source(source, cell_path)
         violations.extend(cell_violations)
     return violations

--- a/tests/test_chkstyle.py
+++ b/tests/test_chkstyle.py
@@ -135,7 +135,7 @@ def test_chkstyle_notebook_shows_cell_id_in_path(tmp_path):
     violations = _check_nb(tmp_path, ["x: int = 1\n"])
     assert len(violations) == 1
     vpath, lineno, msg, lines = violations[0]
-    assert ":cell[cell0]" in vpath and lineno == 1
+    assert ":cell[000#cell0]" in vpath and lineno == 1
 
 def test_chkstyle_notebook_shows_line_within_cell(tmp_path):
     violations = _check_nb(tmp_path, ["# ok\n# still ok\nx: int = 1\n"])


### PR DESCRIPTION
I had a hard time finding my edited cells. The tool reports around 100 issues on lisette/00_core.ipynb, and they are in random order (sorted by random cell id). It is hard to filter them. This is a quick fix that prepends cell idx to cell_id, to let me use the tool on a notebook. How would an ideal marker look like? Do we want to include the tool output in solveit?

Here is how the tool output looks like now. I've added violations to mark the range of cells I've modified:
```markdown
# 00_tmp.ipynb:cell[156#df219bee]:14: if single-statement body not one-liner
    if self.extra_headers: 
        kwargs['extra_headers'] = self.extra_headers # mark the first cell with changes
# 00_tmp.ipynb:cell[157#3580347d]:12: if single-statement body not one-liner
    if prefill: 
        contents(res).content = prefill + (contents(res).content or "")
# 00_tmp.ipynb:cell[161#266f3d5d]:11: if single-statement body not one-liner
    if kwargs.get('stream'): 
        return result_gen # mark the last cell with changes
```

This brings another issue the tool does not seems report the style violations you seen in the #101 , but I guess the issue was in : _flatmap_call and how it uses match case. Should I try to get this tool to report issues for match/case?