### PR TITLE
Count logical lines in the notebook cell-length rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,8 +319,8 @@ nbdev notebooks are literate source: the rendered page is documentation, so code
 | Rule id | Fires when |
 |---|---|
 | `too-many-defs` | a cell has more than 3 top-level defs or classes |
-| `long-exported-cell` | an exported cell has more than 50 code lines |
-| `long-example-cell` | a non-exported cell has more than 10 code lines |
+| `long-exported-cell` | an exported cell has more than 50 logical code lines (a multiline string is one line) |
+| `long-example-cell` | a non-exported cell has more than 10 logical code lines |
 | `undocumented-export` | an exported cell defines a public def or class with no markdown cell directly before or after |
 | `comment-in-example` | a non-exported cell contains a comment (docments excluded): the comment usually belongs in a markdown cell |
 | `exported-run` | more than 2 exported cells in a row with no markdown between |

--- a/chkstyle/core.py
+++ b/chkstyle/core.py
@@ -1105,8 +1105,10 @@ def _narrative_cells(nb, path: str) -> tuple[list[dict], bool]:
         if not n: continue
         tree = None
         if not source.lstrip().startswith("%%"):
-            try: tree = ast.parse("\n".join(_neutralize_ipython(lines)))
+            neut = "\n".join(_neutralize_ipython(lines))
+            try: tree = ast.parse(neut)
             except SyntaxError: pass
+            if tree: n = sum(1 for t in tokenize.generate_tokens(io.StringIO(neut).readline) if t.type == tokenize.NEWLINE)
         cells.append(dict(typ="code", path=f"{path}:cell[{cell.get('id', 'unknown')}]", source=source, lines=lines, n=n,
             tree=tree, export=bool(NB_EXPORT_KEYS & d.keys()), hide="hide" in d,
             skip=should_skip_file(lines) or "nbdev_export()" in source))

--- a/tests/test_chkstyle.py
+++ b/tests/test_chkstyle.py
@@ -787,6 +787,20 @@ def test_chkstyle_notebook_narrative_exemptions(tmp_path):
     assert _check_nb(tmp_path, ungated) == []
     assert _rules(chkstyle.check_notebook(str(_write_nb(tmp_path, "index.ipynb", ungated)))) == {"comment-in-example"}
 
+def test_chkstyle_narrative_counts_logical_lines(tmp_path):
+    "Multiline strings are one logical unit, so a big docstring or literal doesn't make a cell 'long'."
+    doc_lines = "\n".join(f"line {i}" for i in range(60))
+    big_str = '"""\n' + "line\n" * 15 + '"""'
+    cells = [
+        "#| default_exp core\n",
+        _md("words"),
+        f'#| export\ndef pub():\n    """Docs.\n\n{doc_lines}\n    """\n    return 1\n',
+        _md("more words"),
+        f"ask({big_str})\n",
+    ]
+    assert _check_nb(tmp_path, cells) == []
+
+
 def test_chkstyle_config_nb_narrative_flag(tmp_path, capsys):
     "`nb-narrative = false` disables the narrative rules but not mixed-imports."
     p = _write_nb(tmp_path, "index.ipynb", ["y1  # a comment\n"])


### PR DESCRIPTION
`long-exported-cell` and `long-example-cell` counted physical lines, so a
multiline string counted once per line it spans: a docstring or a long
triple-quoted prompt could push a three-statement cell over the limit.

When a cell parses, the count is now its logical lines (tokenize NEWLINE
tokens). Multiline strings and bracketed continuations count once, and
comment-only lines don't count at all. Cells that don't parse, such as
magic cells, keep the physical count. Thresholds are unchanged, so the
change only relaxes: nothing that passed before fails now.

The rule table in the README's "Notebook narrative rules" section
documents the counting.